### PR TITLE
Make scroll speed and scroll region size configurable.

### DIFF
--- a/src/MoveContainer.js
+++ b/src/MoveContainer.js
@@ -31,8 +31,13 @@ export default class MoveContainer extends React.Component {
     makeDragHandle: PropTypes.func.isRequired
   };
 
+  constructor(props) {
+    super(props);
+    this.refs = {};
+  }
+
   getTemplate(): React.Component<any,any,any> {
-    return this.refs.templateContainer.getTemplate();
+    return this.templateContainer.getTemplate();
   }
 
   shouldComponentUpdate(nextProps: Props): boolean {
@@ -67,7 +72,7 @@ export default class MoveContainer extends React.Component {
         }}
       >
         <TemplateContainer
-          ref="templateContainer"
+          ref={cmp => this.templateContainer = cmp}
           item={item}
           template={template}
           itemSelected={itemSelected}

--- a/src/TemplateContainer.js
+++ b/src/TemplateContainer.js
@@ -27,7 +27,7 @@ export default class TemplateContainer extends React.Component {
   }
 
   getTemplate(): React.Component<any,any,any> {
-    return this.refs.template;
+    return this.template;
   }
 
   render() {
@@ -36,7 +36,7 @@ export default class TemplateContainer extends React.Component {
 
     return (
       <Template
-        ref="template"
+        ref={cmp => this.template = cmp}
         item={item}
         itemSelected={itemSelected}
         anySelected={anySelected}

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,11 @@ const DEFAULT_HEIGHT = {natural: 200, drag: 30};
 const AUTOSCROLL_REGION_SIZE = 30;
 const AUTOSCROLL_MAX_SPEED = 15;
 
-function getScrollSpeed(distance) {
+function getScrollSpeed(distance, speed, size) {
   // If distance is zero, then the result is the max speed. Otherwise,
   // the result tapers toward zero as it gets closer to the opposite
   // edge of the region.
-  return Math.round(AUTOSCROLL_MAX_SPEED -
-    (AUTOSCROLL_MAX_SPEED/AUTOSCROLL_REGION_SIZE) * distance);
+  return Math.round(speed - (speed / size) * distance);
 }
 
 type Drag = {
@@ -66,12 +65,16 @@ export default class DraggableList extends React.Component {
     container: PropTypes.func,
     springConfig: PropTypes.object,
     padding: PropTypes.number,
-    unsetZIndex: PropTypes.bool
+    unsetZIndex: PropTypes.bool,
+    maxSpeed: PropTypes.number.isRequired,
+    regionSize: PropTypes.number.isRequired
   };
   static defaultProps: DefaultProps = {
     springConfig: {stiffness: 300, damping: 50},
     padding: 10,
-    unsetZIndex: false
+    unsetZIndex: false,
+    maxSpeed: AUTOSCROLL_MAX_SPEED,
+    regionSize: AUTOSCROLL_REGION_SIZE
   };
   _itemRefs: Map<string, MoveContainer> = new Map();
   _heights: Map<string, {natural: number, drag: number}> = new Map();
@@ -204,7 +207,11 @@ export default class DraggableList extends React.Component {
   };
 
   _handleMouseMove: Function = ({pageY, clientY}) => {
-    const {padding} = this.props;
+    const {
+      padding,
+      maxSpeed,
+      regionSize
+    } = this.props;
     const {list, dragging, lastDrag} = this.state;
     if (!dragging || !lastDrag) return;
 
@@ -228,14 +235,14 @@ export default class DraggableList extends React.Component {
       const top = Math.max(0, containerRect.top);
 
       const distanceFromTop = clientY-top;
-      if (distanceFromTop > 0 && distanceFromTop < AUTOSCROLL_REGION_SIZE) {
-        scrollSpeed = -1 * getScrollSpeed(distanceFromTop);
+      if (distanceFromTop > 0 && distanceFromTop < regionSize) {
+        scrollSpeed = -1 * getScrollSpeed(distanceFromTop, maxSpeed, regionSize);
       } else {
         // Get the lowest of the screen bottom and the container bottom.
         const bottom = Math.min(window.innerHeight, containerRect.bottom);
         const distanceFromBottom = bottom-clientY;
-        if (distanceFromBottom > 0 && distanceFromBottom < AUTOSCROLL_REGION_SIZE) {
-          scrollSpeed = getScrollSpeed(distanceFromBottom);
+        if (distanceFromBottom > 0 && distanceFromBottom < regionSize) {
+          scrollSpeed = getScrollSpeed(distanceFromBottom, maxSpeed, regionSize);
         }
       }
 


### PR DESCRIPTION
In my use case, I have a list with hundreds of items, and the default scroll speed and region size aren't quite usable. This change allows a developer to better control how quickly to scroll.