### PR TITLE
Ignore .babelrc when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ npm-debug.log
 /flow-typed
 *.test.*
 /yarn.lock
+.babelrc


### PR DESCRIPTION
This causes problems when using webpack to compile a project which is dependent on `react-draggable-list`. It tries using the `.babelrc` but AFAICT that's not necessary because the source was already transpiled before being published.