### PR TITLE
Add order prop to Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The template component is passed the following props:
 * `dragHandle` is a function which should be used during rendering to wrap the
  element to be used as the drag handle. The whole item will be draggable by the
  wrapped element.
+* `order` is the index of the item in the list. Upon reorder, the order gives you
+the index of the item as it is ordered in the UI.
 * `commonProps` will be set to the same value passed as the `commonProps` prop
  to the DraggableList component.
 

--- a/src/MoveContainer.js
+++ b/src/MoveContainer.js
@@ -13,6 +13,7 @@ type Props = {
   height: Object;
   zIndex: number|string;
   makeDragHandle: Function;
+  order: number;
   commonProps?: ?Object;
 };
 export default class MoveContainer extends React.Component<Props> {
@@ -40,7 +41,8 @@ export default class MoveContainer extends React.Component<Props> {
 
   render() {
     const {
-      item, y, padding, itemSelected, anySelected, height, zIndex, template, commonProps
+      item, y, padding, itemSelected, anySelected, height, zIndex, template, commonProps,
+      order
     } = this.props;
 
     return (
@@ -60,6 +62,7 @@ export default class MoveContainer extends React.Component<Props> {
         <TemplateContainer
           ref={this._templateContainerSetter}
           item={item}
+          order={order}
           template={template}
           itemSelected={itemSelected}
           anySelected={anySelected}

--- a/src/TemplateContainer.js
+++ b/src/TemplateContainer.js
@@ -8,6 +8,7 @@ type Props = {
   itemSelected: number;
   anySelected: number;
   dragHandle: Function;
+  order:number;
   commonProps?: ?Object;
 };
 export default class TemplateContainer extends React.Component<Props> {
@@ -29,13 +30,14 @@ export default class TemplateContainer extends React.Component<Props> {
   }
 
   render() {
-    const {item, itemSelected, anySelected, dragHandle, commonProps} = this.props;
+    const {item, itemSelected, anySelected, dragHandle, order, commonProps} = this.props;
     const Template = this.props.template;
 
     return (
       <Template
         ref={this._templateSetter}
         item={item}
+        order={order}
         itemSelected={itemSelected}
         anySelected={anySelected}
         dragHandle={dragHandle}

--- a/src/index.js
+++ b/src/index.js
@@ -433,6 +433,7 @@ export default class DraggableList extends React.Component<Props, State> {
               itemSelected={itemSelected}
               anySelected={anySelected}
               height={height}
+              order={i}
               zIndex={unsetZIndex && !useAbsolutePositioning ? 'auto' :
                 (lastDrag && lastDrag.itemKey === key ? list.length : i)
               }


### PR DESCRIPTION
Send down `order` prop, which is the index of the item in the list (or reordered list).

Use case
---------
I am using this library to render a series of thumbnails for slides in a slide deck. The user can reorder the slides by dragging the slide thumbnails. This works great, but there is a problem. Along with each slide thumbnail, its numerical index needs to be shown. For e.g

```
   1. Slide 1
   2. Slide 2
```

after re-order:
```
  1. Slide 2
  2. Slide 1
```
The problem is that I cannot store the index on the item and use that to render the number in the Template. This would result in the numbers being 2. and 1. respectively. What I need instead, is the new order in the reordered list, so that I can display that number.

Previous Attempts
-------------------
1. Use `<ol>` wrapper component, and `<li>` template component so that browser will show correct order. But `<Motion>` wrapper results in a `<div>` container (with absolute position) being inserted around the `<li>` leading to semantically incorrect HTML.

2. Use a static property to pass down the reordered list. Then inside the `Template` component, use  reorderedList.indexOf(slide.id) to get index. However, this is a massive hack and works iff there is only one draggable list on the page.


Update: I just found the issue filed: https://github.com/StreakYC/react-draggable-list/issues/24

P.S
I've made no updates to package version.