### PR TITLE
add onItemClick prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ following props:
 - `onDragStart` is an optional function which is called once a list item starts
   being dragged.
 - `onDragEnd` is an optional function which is called once a list item is no longer being dragged. It differs from `onMoveEnd` in that it's called even if the user does not reorder any items in the lists, like when an item is just picked up and then dropped.
+- `onItemClick` is an optional function which is called once a list item is clicked or touched. It provides `clickedItem: Object` as an argument. Use this prop if you want the user to be able to select some item in the list and run custom logic with that item, regardless of if it is dragged.
 
 A DraggableList instance has the following methods:
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,7 @@ export interface Props<I, C, T> {
   commonProps?: C;
   onDragStart?: () => void;
   onDragEnd?: () => void;
+  onItemClick?: (clickedItem: I) => void;
 }
 interface State {
   useAbsolutePositioning: boolean;
@@ -150,6 +151,14 @@ export default class DraggableList<
     event: TouchEvent | React.TouchEvent
   ) {
     event.stopPropagation();
+    
+    const { list, onItemClick } = this.props;
+    if(onItemClick) {
+      const keyFn = this._getKeyFn();
+      const itemIndex = DraggableList._getIndexOfItemWithKey(keyFn, list, itemKey);
+      onItemClick(list[itemIndex])
+    }
+
     this._handleStartDrag(itemKey, pressY, event.touches[0].pageY);
   }
 
@@ -159,6 +168,14 @@ export default class DraggableList<
     event: MouseEvent | React.MouseEvent
   ) {
     event.preventDefault();
+
+    const { list, onItemClick } = this.props;
+    if(onItemClick) {
+      const keyFn = this._getKeyFn();
+      const itemIndex = DraggableList._getIndexOfItemWithKey(keyFn, list, itemKey);
+      onItemClick(list[itemIndex])
+    }
+
     this._handleStartDrag(itemKey, pressY, event.pageY);
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -153,10 +153,10 @@ export default class DraggableList<
     event.stopPropagation();
     
     const { list, onItemClick } = this.props;
-    if(onItemClick) {
+    if (onItemClick) {
       const keyFn = this._getKeyFn();
       const itemIndex = DraggableList._getIndexOfItemWithKey(keyFn, list, itemKey);
-      onItemClick(list[itemIndex])
+      onItemClick(list[itemIndex]);
     }
 
     this._handleStartDrag(itemKey, pressY, event.touches[0].pageY);
@@ -170,10 +170,10 @@ export default class DraggableList<
     event.preventDefault();
 
     const { list, onItemClick } = this.props;
-    if(onItemClick) {
+    if (onItemClick) {
       const keyFn = this._getKeyFn();
       const itemIndex = DraggableList._getIndexOfItemWithKey(keyFn, list, itemKey);
-      onItemClick(list[itemIndex])
+      onItemClick(list[itemIndex]);
     }
 
     this._handleStartDrag(itemKey, pressY, event.pageY);


### PR DESCRIPTION
`onItemClick` is an optional function which is called once a list item is clicked or touched. It provides `clickedItem: Object` as an argument. Use this prop if you want the user to be able to select some item in the list and run custom logic with that item, regardless of if it is dragged.