### PR TITLE
fix: Hasn't accept a JSX Element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,7 @@ export interface TemplateProps<I, C> {
 
 export interface Props<I, C, T> {
   itemKey: string | ((item: I) => string);
-  template: new (props: any, context?: any) => T;
+  template: (props: any, context?: any) => React.JSX.Element;
   list: ReadonlyArray<I>;
   onMoveEnd?: (
     newList: ReadonlyArray<I>,


### PR DESCRIPTION
The `template` property don't accept functional components that return JSX Element,  which is currently most common in React and Next community.

That Pull Request fix it.